### PR TITLE
Enable users to click on the filter/attribute name to select it

### DIFF
--- a/conf/templates/default/attribute.tt
+++ b/conf/templates/default/attribute.tt
@@ -77,7 +77,7 @@
 [% END %]
 
 [% IF attribute.description %]
-<a title="[% attribute.description | replace('"','&quot;') %]">[% attribute_displayname %]</a>
+<span title="[% attribute.description | replace('"','&quot;') %]">[% attribute_displayname %]</span>
 [% ELSE %]
   [% attribute_displayname %]
 [% END %]

--- a/conf/templates/default/attribute.tt
+++ b/conf/templates/default/attribute.tt
@@ -10,7 +10,7 @@
 [% attribute_displayname = attribute.displayName() %]
 [% attribute_parname = "\${param_prefix}"_ attributetree.name _ "__attribute.$attribute.name" %]
 [% attributecollection_parname = "[* param_prefix*]${attributetree.name}__attributecollection.${attributecollection.name}" %] 
-<div class="attribute" id="[% attribute_parname %]__container">
+<div class="attribute" id="[% attribute_parname %]__container"><label>
 [% # Render checkbox and attribute name, but only if we could actually retrieve the info %]
 [% IF attribute_displayname != 0 %]
 
@@ -109,4 +109,4 @@
 
 [% END %]
 
-</div>
+</label></div>

--- a/conf/templates/default/attributefilter.tt
+++ b/conf/templates/default/attributefilter.tt
@@ -82,7 +82,7 @@
 [% END %]
 
 [% IF attribute.description %]
-  <acronym title="[% attribute.description | replace('"','&quot;') %]">[% attribute_displayname %]</acronym>
+  <span title="[% attribute.description | replace('"','&quot;') %]">[% attribute_displayname %]</span>
 [% ELSE %]
   [% attribute_displayname %]
 [% END %]

--- a/conf/templates/default/attributepanel.tt
+++ b/conf/templates/default/attributepanel.tt
@@ -60,7 +60,7 @@
 	
 	[% IF attributetree_count > 1 %]
 		[% IF attributetree.description %]
-		<a title="[% attributetree.description | replace('"','&quot;') %]">[% attributetree.displayName() %]</a>
+		<span title="[% attributetree.description | replace('"','&quot;') %]">[% attributetree.displayName() %]</span>
 	  	[% ELSE %]
 		[% attributetree.displayName() %]
 	  	[% END %]
@@ -141,7 +141,7 @@
 	[% attributes = attributecollection.getAllAttributes() %]
 		[% IF attributes.size > 0 %]
 		<span class="mart_attributecollection_title">[% IF attributecollection.description %]
-		<a title="[% attributecollection.description | replace('"','&quot;') %]">$attributecollection.displayName</a>
+		<span title="[% attributecollection.description | replace('"','&quot;') %]">$attributecollection.displayName</span>
 		[% ELSE %]
 		$attributecollection.displayName
 	  	[% END %]</span>

--- a/conf/templates/default/collapsible_section.tt
+++ b/conf/templates/default/collapsible_section.tt
@@ -28,7 +28,7 @@ ctl_visible_AttFiltPanel
   </span>
   <span style="display: inline">
   [% IF section_description %]
-  <a title="[% section_description | replace('"','&quot;') %]">$section_displayname</a>
+  <span title="[% section_description | replace('"','&quot;') %]">$section_displayname</span>
   [% ELSE %]
   $section_displayname
   [% END %]
@@ -90,7 +90,7 @@ el_hidden_AttFiltPanel" style="display: none
   	">
   	
   [% IF section_description %]
-  <a title="[% section_description | replace('"','&quot;') %]"> $section_displayname</a>
+  <span title="[% section_description | replace('"','&quot;') %]"> $section_displayname</span>
   [% ELSE %]
   $section_displayname
   [% END %]

--- a/conf/templates/default/filter.tt
+++ b/conf/templates/default/filter.tt
@@ -32,7 +32,7 @@
 <div class="mart_filtername" onmouseover=""><label>
   [% render_filtercollection_checkbox(filter, filtercollection2show) %]  
   [% IF filtercollection.description %]
-  <a title="[% filtercollection.description | replace('"','&quot;') %]">$filtercollection.displayName</a>
+  <span title="[% filtercollection.description | replace('"','&quot;') %]">$filtercollection.displayName</span>
   [% ELSE %]
   $filtercollection.displayName
   [% END %]
@@ -42,7 +42,7 @@
 <div class="mart_filtername" onmouseover="" style="margin-left: 22px"><label>
 
   [% IF filter.description %]
-  <a title="[% filter.description | replace('"','&quot;') %]">$filter.displayName</a>
+  <span title="[% filter.description | replace('"','&quot;') %]">$filter.displayName</span>
   [% ELSE %]
   $filter.displayName
   [% END %]

--- a/conf/templates/default/filter.tt
+++ b/conf/templates/default/filter.tt
@@ -29,21 +29,24 @@
 <td align="left" width="45%" valign="top">
 
 [% IF filtercollection2show %]
-<div class="mart_filtername" onmouseover="">
+<div class="mart_filtername" onmouseover=""><label>
   [% render_filtercollection_checkbox(filter, filtercollection2show) %]  
   [% IF filtercollection.description %]
   <a title="[% filtercollection.description | replace('"','&quot;') %]">$filtercollection.displayName</a>
   [% ELSE %]
   $filtercollection.displayName
   [% END %]
+  </label>
+
 [% ELSE %]
-<div class="mart_filtername" onmouseover="" style="margin-left: 22px">
+<div class="mart_filtername" onmouseover="" style="margin-left: 22px"><label>
 
   [% IF filter.description %]
   <a title="[% filter.description | replace('"','&quot;') %]">$filter.displayName</a>
   [% ELSE %]
   $filter.displayName
   [% END %]
+  </label>
 
 [% END %]
 

--- a/conf/templates/default/filter_checkboxlist.tt
+++ b/conf/templates/default/filter_checkboxlist.tt
@@ -50,7 +50,7 @@
                 [* END *]
  		/>
 	 	[% IF option.description %]
-  			<a title="[% option.description | replace('"','&quot;') %]">[% option_displayname %]</a>
+  			<span title="[% option.description | replace('"','&quot;') %]">[% option_displayname %]</span>
 	  	[% ELSE %]
   			[% option_displayname %]
   		[% END %]<br/>

--- a/conf/templates/default/filter_radiobuttonlist.tt
+++ b/conf/templates/default/filter_radiobuttonlist.tt
@@ -48,7 +48,7 @@ document['${param_name}__image'].src='${filter.imageURL}';
 [* is_first_option = 0 *]
 [* END *]
  />[% IF option.description %]
-  <a title="[% option.description | replace('"','&quot;') %]">[% option_displayname %]</a>
+  <span title="[% option.description | replace('"','&quot;') %]">[% option_displayname %]</span>
   [% ELSE %]
   [% option_displayname %]
   [% END %]<br />

--- a/conf/templates/default/filterpanel.tt
+++ b/conf/templates/default/filterpanel.tt
@@ -73,12 +73,14 @@
 
 				[% filtercollection_paramname = "\${param_prefix}filtercollection." _ filtercollection.name %] 
 
+        <label>
 				[% render_filtercollection_checkbox(filters.0, filtercollection) %]
 				[% IF filtercollection.description %]
-				  <a title="[% filtercollection.description | replace('"','&quot;') %]">$filtercollection.displayName</a>
+				  <span title="[% filtercollection.description | replace('"','&quot;') %]">$filtercollection.displayName</span>
 				[% ELSE %]
 					$filtercollection.displayName
 				[% END %]
+        </label>
 				[% # Get all non-hidden filters in this filtercollection and render them %]
 
 				[% FOREACH filter = filtercollection.getAllFilters() %]

--- a/htdocs/biomart/mview/js/martview.js
+++ b/htdocs/biomart/mview/js/martview.js
@@ -895,22 +895,48 @@ function getFiltersInContainer(containerEltId) {
 					if(divs[i].childNodes[p].nodeName == '#text'
 					&& divs[i].childNodes[p].nodeValue 
 					&& divs[i].childNodes[p].nodeValue.match(/\w/)) {
-						currentFilterDisplayName = divs[i].childNodes[p].nodeValue;
+						currentFilterDisplayName = divs[i].childNodes[p].nodeValue.trim();
 						//alert('Got valid string for filtername: '+currentFilterDisplayName);
 					break;
 					}
 				}
-				// If we got here, then it's probably inside an acronym. Read that instead.
+				// If we got here, then it's probably inside a span. Read that instead.
 				for(var p=0; p<divs[i].childNodes.length;p++) {
-					if(divs[i].childNodes[p].nodeName == 'a' || divs[i].childNodes[p].nodeName == 'A') {
+					if(divs[i].childNodes[p].nodeName == 'span' || divs[i].childNodes[p].nodeName == 'SPAN') {
 						var acroNodeValue = divs[i].childNodes[p].innerHTML;
 						if(acroNodeValue && acroNodeValue.match(/\w/)) {
-							currentFilterDisplayName = acroNodeValue;
+							currentFilterDisplayName = acroNodeValue.trim();
 							//alert('Got valid string for filtername: '+currentFilterDisplayName);
 							break;
 						}
 					}
 				}
+        
+        for(var p=0; p<divs[i].childNodes.length;p++) {
+          if(divs[i].childNodes[p].nodeName == 'label' || divs[i].childNodes[p].nodeName == 'LABEL') {
+            var label_node = divs[i].childNodes[p];
+            for(var q=0; q<label_node.childNodes.length;q++) {
+              if(label_node.childNodes[q].nodeName == '#text'
+              && label_node.childNodes[q].nodeValue 
+              && label_node.childNodes[q].nodeValue.match(/\w/)) {
+                currentFilterDisplayName = label_node.childNodes[q].nodeValue.trim();
+                //alert('Got valid string for filtername: '+currentFilterDisplayName);
+              break;
+              }
+            }
+            // If we got here, then it's probably inside a span. Read that instead.
+            for(var q=0; q<label_node.childNodes.length;q++) {
+              if(label_node.childNodes[q].nodeName == 'span' || label_node.childNodes[q].nodeName == 'SPAN') {
+                var acroNodeValue = label_node.childNodes[q].innerHTML;
+                if(acroNodeValue && acroNodeValue.match(/\w/)) {
+                  currentFilterDisplayName = acroNodeValue.trim();
+                  //alert('Got valid string for filtername: '+currentFilterDisplayName);
+                  break;
+                }
+              }
+            }
+          }
+        }
 			break;
 			case 'mart_filtervalue':
 				// The filterval-div could have a number of form elements, such as upload buttons etc.

--- a/htdocs/martview/js/martview.js
+++ b/htdocs/martview/js/martview.js
@@ -895,22 +895,48 @@ function getFiltersInContainer(containerEltId) {
 					if(divs[i].childNodes[p].nodeName == '#text'
 					&& divs[i].childNodes[p].nodeValue 
 					&& divs[i].childNodes[p].nodeValue.match(/\w/)) {
-						currentFilterDisplayName = divs[i].childNodes[p].nodeValue;
+						currentFilterDisplayName = divs[i].childNodes[p].nodeValue.trim();
 						//alert('Got valid string for filtername: '+currentFilterDisplayName);
 					break;
 					}
 				}
-				// If we got here, then it's probably inside an acronym. Read that instead.
+				// If we got here, then it's probably inside a span. Read that instead.
 				for(var p=0; p<divs[i].childNodes.length;p++) {
-					if(divs[i].childNodes[p].nodeName == 'a' || divs[i].childNodes[p].nodeName == 'A') {
+					if(divs[i].childNodes[p].nodeName == 'span' || divs[i].childNodes[p].nodeName == 'SPAN') {
 						var acroNodeValue = divs[i].childNodes[p].innerHTML;
 						if(acroNodeValue && acroNodeValue.match(/\w/)) {
-							currentFilterDisplayName = acroNodeValue;
+							currentFilterDisplayName = acroNodeValue.trim();
 							//alert('Got valid string for filtername: '+currentFilterDisplayName);
 							break;
 						}
 					}
 				}
+        
+        for(var p=0; p<divs[i].childNodes.length;p++) {
+          if(divs[i].childNodes[p].nodeName == 'label' || divs[i].childNodes[p].nodeName == 'LABEL') {
+            var label_node = divs[i].childNodes[p];
+            for(var q=0; q<label_node.childNodes.length;q++) {
+              if(label_node.childNodes[q].nodeName == '#text'
+              && label_node.childNodes[q].nodeValue 
+              && label_node.childNodes[q].nodeValue.match(/\w/)) {
+                currentFilterDisplayName = label_node.childNodes[q].nodeValue.trim();
+                //alert('Got valid string for filtername: '+currentFilterDisplayName);
+              break;
+              }
+            }
+            // If we got here, then it's probably inside a span. Read that instead.
+            for(var q=0; q<label_node.childNodes.length;q++) {
+              if(label_node.childNodes[q].nodeName == 'span' || label_node.childNodes[q].nodeName == 'SPAN') {
+                var acroNodeValue = label_node.childNodes[q].innerHTML;
+                if(acroNodeValue && acroNodeValue.match(/\w/)) {
+                  currentFilterDisplayName = acroNodeValue.trim();
+                  //alert('Got valid string for filtername: '+currentFilterDisplayName);
+                  break;
+                }
+              }
+            }
+          }
+        }
 			break;
 			case 'mart_filtervalue':
 				// The filterval-div could have a number of form elements, such as upload buttons etc.


### PR DESCRIPTION
Adding <label> tags means that you can click on the text next to the checkbox to select it, for both filters and attributes. I believe this works in all browsers, but should degrade nicely in any case. Any reason not to do this?
