### PR TITLE
Truncate long option names

### DIFF
--- a/conf/templates/default/filter_selectmenu.tt
+++ b/conf/templates/default/filter_selectmenu.tt
@@ -74,12 +74,24 @@ document['${param_name}__image'].src='${filter.imageURL}';
   [% # Gotta do some funky stuff here so quotes in strings don't mess up HTML or JavaScript %]
   [% option_value = option.value() || option.name() %]
   [% option_value_escaped = option_value | replace('"','&quot;')  #" %]
-  [% option_displayname = option.displayName() | replace('"','&quot;') #" %]
+  [% option_displayname_escaped = option.displayName() | replace('"','&quot;') #" %]
+  [% option_displayname = option_displayname_escaped || option_value_escaped %]
 
+  <option value="[% option_value_escaped %]" title="[% option_displayname %]">
 	
-	<option value="[% option_value_escaped %]"
+	[% IF option_displayname.length > 60 %]
+    [% option_truncated = '' %]
+    [% FOREACH word IN option_displayname.split(' ') %]
+      [% IF (option_truncated.length + word.length) < 60 %]
+        [% option_truncated = option_truncated _ ' ' _ word %]
+      [% END %]
+    [% END %]
+    [% option_truncated %] ...
+  [% ELSE %]
+    [% option_displayname %]
+  [% END %]
 
->[% option_displayname || option_value_escaped %]</option>
+  </option>
 
   [% # Process pushactions for this option, if any %]
   [% process_pushactions(option, option_value, param_name, dataset_name) %]

--- a/conf/templates/default/filterpanel.tt
+++ b/conf/templates/default/filterpanel.tt
@@ -21,7 +21,7 @@
 <tr>
 <td width="100%" height="100%" valign="top" align="left">
 
-<div class="dummyLine_1" align="center"><b>Please restrict your query using criteria below</b></div>
+<div class="dummyLine_1" align="center"><b>Please restrict your query using criteria below</b><br />(If filter values are truncated in any lists, hover over the list item to see the full text)</div>
 
 <div class="mart_filterpanel">
 


### PR DESCRIPTION
Long descriptive study names have appeared recently, which look horrible when they're put into dropdown lists, introducing horizontal scroll bars within that filter section. This change truncates anything longer than 60 characters, and the full text shows when you mouseover the item in the list. This potentially affects all options in all marts, but for metazoa the only place it is required is in study/population names in variation marts.
