### PR TITLE
temporary fix

### DIFF
--- a/lib/BioMart/Dataset/GenomicSequence.pm
+++ b/lib/BioMart/Dataset/GenomicSequence.pm
@@ -358,7 +358,9 @@ sub _editSequence {
 		    print STDERR "$key $seq_edit\n";
 			my ($start, $end, $alt_seq) = split /\,/, $seq_edit;
 			my $len = $end - $start + 1;
-			substr($$seqref, $start - 1, $len) = $alt_seq;
+                    
+                        eval{substr($$seqref, $start - 1, $len) = $alt_seq}
+                            or $$seqref = "Sequence unavailable";
 		}
 	}
 	


### PR DESCRIPTION
This is a hacky, temporary patch for https://www.ebi.ac.uk/panda/jira/browse/ENSEMBL-4324

It simply stops the BioMart process from 'falling over' when creating the peptide sequence for AT5G18710.1, but not much else. i.e. there is a fundamental issue regarding Ensembl transcript seq-edits being called on cDNA. @danstaines or @thomasmaurel ?
